### PR TITLE
Feature metadata

### DIFF
--- a/bin/R/create_helpers.R
+++ b/bin/R/create_helpers.R
@@ -1,5 +1,5 @@
-suppressMessages({
     library(tidyr)
+suppressMessages({
     library(dplyr)
     library(magrittr)
     library(stringr)
@@ -20,27 +20,34 @@ loadQuantsH5 <- function(quants)
 
 readTranscriptMap <- function(reference_dir, class=TRUE)
 {
-    map = reference_dir %>% 
+    reference_dir %>% 
         list.files(full.names=TRUE) %>%
         str_subset("complete_map.tx2g") %>%
         read_csv(col_names=TRUE, progress=FALSE, show_col_types=FALSE) %>%
         select(gene_id, gene_name, gene_biotype) %>%
         distinct() %>%
         mutate(
-            gene_biotype=case_when(
+            biotype=case_when(
                 !str_detect(gene_biotype, ",") ~ gene_biotype,
                 TRUE ~ unlist(lapply(gene_biotype, function(x){strsplit(x, ",")[[1]][ifelse(class, 2, 1)]}))
-            )
-        )%>%
-        mutate(
-            gene_biotype=case_when(
-                startsWith(gene_biotype, "Mt-") | startsWith(gene_name, "Mt-") ~ "Mitochondrial",
-                gene_biotype == "protein_coding" ~ "Coding",
-                gene_biotype %in% c("lncRNA", "LINE", "SINE", "LTR", "DNA") ~ gene_biotype,
-                gene_biotype == "Simple_repeat" ~ "Microsatellite",
-                TRUE ~ "Other"
+            ),
+            biotype_class=case_when(
+                grepl(',', gene_biotype) ~ "repeat",
+                TRUE ~ "gene"
             )
         ) %>%
+        mutate(
+            gene_biotype=case_when(
+                startsWith(biotype, "Mt_") | startsWith(gene_name, "MT-") ~ "Mitochondrial",
+                biotype == "protein_coding" ~ "Coding",
+                biotype %in% c("lncRNA", "miRNA", "LINE", "SINE", "LTR", "DNA") ~ biotype,
+                biotype == "Simple_repeat" ~ "Microsatellite",
+                biotype=="Satellite" ~ "Human satellite",
+                biotype_class =="gene" ~ "Other gene",
+                TRUE ~ "Other repeat"
+            )
+        ) %>%
+        select(gene_id, gene_name, gene_biotype) %>%
         return()
 }
 
@@ -153,12 +160,15 @@ createTheme <- function()
 
 biotype_colors = list(
     "Coding" = "#404040",
-    "lncRNA" = "#00DAE6",
-    "SINE" = "#BD4F00",
-    "LTR" = "#88D100",
-    "LINE" = "#6A0094",
-    "DNA" = "#010A80",
-    "Microsatellite" = "#A80202",
-    "Mitochondrial" = "#006B1E",
-    "Other" = "#574400"
+    "lncRNA" = "#5EFFF2",
+    "miRNA" = "#E64900",
+    "Mitochondrial" = "#424780",
+    "Microsatellite" = "#327300",
+    "SINE" = "#997800",
+    "LINE" = "#88008C",
+    "LTR" = "#7FBF4E",
+    "DNA" = "#0012D9",
+    "Human satellite" = "#005952",
+    "Other gene" = "#F2D361",
+    "Other repeat" = "#A6603F"
 )


### PR DESCRIPTION
Added intelligent metadata prefix matching to make the metadata sheet easier. Expanded on the number of annotated biotypes to include mitochondrial genes, human satellite elements, and splitting the 'Other' category into genes and repeats.