### PR TITLE
flair_align thread assignment

### DIFF
--- a/modules/flair/flair_align/flair_align.nf
+++ b/modules/flair/flair_align/flair_align.nf
@@ -51,7 +51,7 @@ process flair_align
             flair align \
                 --genome !{reference}/*_genome.fa.gz \
                 --reads !{read} \
-                --threads 8 \
+                --threads !{task.cpus} \
                 --output !{sample}
         '''
 }


### PR DESCRIPTION
`--threads 8` hardcoded. Changed to use `task.cpus`