### PR TITLE
flair_correct.nf thread assignment

### DIFF
--- a/modules/flair/flair_correct/flair_correct.nf
+++ b/modules/flair/flair_correct/flair_correct.nf
@@ -51,7 +51,7 @@ process flair_correct
                 --genome !{reference}/*_genome.fa.gz \
                 --query !{regions} \
                 --gtf annotation.gtf \
-                --threads 8 \
+                --threads !{task.cpus} \
                 --output !{sample}
         '''
 }


### PR DESCRIPTION
`--threads 8` hardcoded in flair correct. Changed to use `task.cpus`.