### PR TITLE
Flair module thread assignments

### DIFF
--- a/modules/flair/flair_align/flair_align.nf
+++ b/modules/flair/flair_align/flair_align.nf
@@ -51,7 +51,7 @@ process flair_align
             flair align \
                 --genome !{reference}/*_genome.fa.gz \
                 --reads !{read} \
-                --threads 8 \
+                --threads !{task.cpus} \
                 --output !{sample}
         '''
 }

--- a/modules/flair/flair_collapse/flair_collapse.nf
+++ b/modules/flair/flair_collapse/flair_collapse.nf
@@ -60,7 +60,7 @@ process flair_collapse
                 --stringent \
                 --check_splice \
                 --generate_map \
-                --threads 8 \
+                --threads !{task.cpus} \
                 --output novel
         '''
 }

--- a/modules/flair/flair_correct/flair_correct.nf
+++ b/modules/flair/flair_correct/flair_correct.nf
@@ -51,7 +51,7 @@ process flair_correct
                 --genome !{reference}/*_genome.fa.gz \
                 --query !{regions} \
                 --gtf annotation.gtf \
-                --threads 8 \
+                --threads !{task.cpus} \
                 --output !{sample}
         '''
 }


### PR DESCRIPTION
Update flair modules to use `task.cpus` for `--threads` 